### PR TITLE
use web-time crate to allow functioning in web browsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-complex = "0.4.0"
 num-traits = "0.2.14"
 ordered-float = "2.10.0"
 thiserror = "1.0.30"
+web-time = "1.1"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/src/gauss_kronrod/mod.rs
+++ b/src/gauss_kronrod/mod.rs
@@ -10,6 +10,7 @@ mod quad;
 use quad::GaussKronrodCore;
 
 /// A Gauss-Kronrod Integrator
+#[derive(Debug, Clone)]
 pub struct GaussKronrod<N> {
     /// The integration order for Gauss integration,
     /// the order used for Gauss-Kronrod is 2 m + 1

--- a/src/gauss_kronrod/quad.rs
+++ b/src/gauss_kronrod/quad.rs
@@ -4,7 +4,7 @@ use nalgebra::ComplexField;
 use num_traits::{Float, FromPrimitive};
 use ordered_float::NotNan;
 use std::collections::BinaryHeap;
-use std::time::Instant;
+use web_time::Instant;
 
 /// A struct to track the progress of a solver, as we pass to sub-routines this allows
 /// us to track the value of the integral and the number of evaluations without passing

--- a/src/result.rs
+++ b/src/result.rs
@@ -6,7 +6,7 @@ pub struct IntegrationResult<T>
 where
     T: ComplexField,
 {
-    running_time: std::time::Duration,
+    running_time: web_time::Duration,
     number_of_function_evaluations: usize,
     pub result: Option<T>,
     pub error: Option<T::RealField>,
@@ -40,7 +40,7 @@ where
         self
     }
 
-    pub fn with_duration(mut self, time_elapsed: std::time::Duration) -> Self {
+    pub fn with_duration(mut self, time_elapsed: web_time::Duration) -> Self {
         self.running_time = time_elapsed;
         self
     }
@@ -59,7 +59,7 @@ where
         IntegrationResult {
             result: None,
             error: None,
-            running_time: std::time::Duration::from_secs(0),
+            running_time: web_time::Duration::from_secs(0),
             number_of_function_evaluations: 0,
         }
     }


### PR DESCRIPTION
Hey there!
I tried using this for wasm in a browser but `std::time` doesn't work in browsers. So this is a quick and easy fix that defaults to std::time when not in a browser.