### PR TITLE
added method for integration of real functions with complex outputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quad-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Christopher R. Gubbin <cgubbin@protonmail.com>"]
 description = "Adaptive Gauss-Kronrod Integration in Rust"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,48 @@ let range = Range {
 let solution = integrator.integrate(Problem {}, range).unwrap();
 ```
 
+## Example - Real to Complex Integration
+
+```rust
+use quad_rs::{Integrable, Integrator};
+use num_complex::Complex;
+use std::ops::Range;
+
+struct Problem {}
+
+impl Integrable for Problem {
+    type Input = f64;
+    type Output = Complex<f64>;
+    fn integrand(
+        &self,
+        input: &Self::Input,
+    ) -> Result<Self::Output, quad_rs::EvaluationError<Self::Input>> {
+        Ok(input.exp())
+    }
+}
+
+let integrator = Integrator::default()
+    .with_maximum_iter(1000)
+    .relative_tolerance(1e-8);
+
+
+let range = Range {
+    start: (-1f64),
+    end: 1f64,
+};
+
+let solution = integrator
+    .integrate_real_complex(Problem {}, range)
+    .unwrap();
+
+let result = solution.result.result.unwrap();
+
+let analytical_result = std::f64::consts::E - 1. / std::f64::consts::E;
+
+dbg!(&result, &analytical_result);
+
+```
+
 ## Example - Contour Integration
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,3 +16,15 @@ pub enum EvaluationError<I> {
     #[error("Possible singularity near {singularity:?}")]
     PossibleSingularity { singularity: I },
 }
+
+impl<R: num_traits::Zero> EvaluationError<R> {
+    pub(crate) fn into_complex(self) -> EvaluationError<num_complex::Complex<R>> {
+        match self {
+            EvaluationError::PossibleSingularity { singularity } => {
+                EvaluationError::PossibleSingularity {
+                    singularity: num_complex::Complex::new(singularity, R::zero()),
+                }
+            }
+        }
+    }
+}

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -95,3 +95,43 @@ fn readme_test_contour() {
     let solution = integrator.contour_integrate(Problem {}, contour).unwrap();
     dbg!(solution.result.result);
 }
+
+#[test]
+fn readme_test_real_to_complex() {
+    use num_complex::Complex;
+    use quad_rs::{Integrable, Integrator};
+
+    struct Problem {}
+
+    impl Integrable for Problem {
+        type Input = f64;
+        type Output = Complex<f64>;
+        fn integrand(
+            &self,
+            input: &Self::Input,
+        ) -> Result<Self::Output, quad_rs::EvaluationError<Self::Input>> {
+            Ok(Complex::new(*input, 0.0).exp())
+        }
+    }
+
+    let integrator = Integrator::default()
+        .with_maximum_iter(1000)
+        .relative_tolerance(1e-8);
+
+    let range = std::ops::Range {
+        start: (-1f64),
+        end: 1f64,
+    };
+
+    let solution = integrator
+        .integrate_real_complex(Problem {}, range)
+        .unwrap();
+
+    let result = solution.result.result.unwrap();
+
+    let analytical_result = std::f64::consts::E - 1. / std::f64::consts::E;
+
+    dbg!(&result, &analytical_result);
+
+    approx::assert_relative_eq!(result.re, analytical_result, max_relative = 1e-10);
+}


### PR DESCRIPTION
In the new release `0.2.0` functionality for integrating functions with real inputs and complex outputs was broken.

To revert this a new method `integrate_real_complex` was added to the integrator class. 